### PR TITLE
chore: add latest `@types/node` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:types": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/node": "^18.14.1",
     "@vitest/coverage-c8": "^0.28.5",
     "eslint": "^8.34.0",
     "eslint-config-unjs": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@types/node': ^18.14.1
   '@vitest/coverage-c8': ^0.28.5
   eslint: ^8.34.0
   eslint-config-unjs: ^0.1.0
@@ -12,6 +13,7 @@ specifiers:
   vitest: ^0.28.5
 
 devDependencies:
+  '@types/node': 18.14.1
   '@vitest/coverage-c8': 0.28.5
   eslint: 8.34.0
   eslint-config-unjs: 0.1.0_7kw3g6rralp5ps6mg3uyzz6azm
@@ -689,8 +691,8 @@ packages:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
     dev: true
 
-  /@types/node/18.6.5:
-    resolution: {integrity: sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==}
+  /@types/node/18.14.1:
+    resolution: {integrity: sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -4352,7 +4354,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.6.5
+      '@types/node': 18.14.1
       '@vitest/expect': 0.28.5
       '@vitest/runner': 0.28.5
       '@vitest/spy': 0.28.5


### PR DESCRIPTION
Related to #65.

I resolved conflicts in my PR, #61, and faced at CI error in `test:types` step.
The error can be fixed by adding the latest `@types/node` package.

But, since #65 was merged with CI failed, I wonder there might be a reason for not adding this package.
I appreciate if you tell me the reason if any, or if you merge this PR so that CI passes for PRs.