### PR TITLE
feat: add function name to hook for better dx in stacktraces

### DIFF
--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -73,7 +73,7 @@ export class Hookable<
 
     // Add name to hook for better debugging experience
     if (!function_.name) {
-      Object.defineProperty(function_, 'name', { get: () => name + ' callback' })
+      Object.defineProperty(function_, 'name', { get: () => name + ' callback', configurable: true })
     }
 
     this._hooks[name] = this._hooks[name] || [];

--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -73,7 +73,10 @@ export class Hookable<
 
     // Add name to hook for better debugging experience
     if (!function_.name) {
-      Object.defineProperty(function_, 'name', { get: () => name + ' callback', configurable: true })
+      Object.defineProperty(function_, "name", {
+        get: () => name + " callback",
+        configurable: true,
+      });
     }
 
     this._hooks[name] = this._hooks[name] || [];

--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -73,10 +73,12 @@ export class Hookable<
 
     // Add name to hook for better debugging experience
     if (!function_.name) {
-      Object.defineProperty(function_, "name", {
-        get: () => '_' + name.replace(/\W+/g, '_') + "_hook_cb",
-        configurable: true,
-      });
+      try {
+        Object.defineProperty(function_, "name", {
+          get: () => "_" + name.replace(/\W+/g, "_") + "_hook_cb",
+          configurable: true,
+        });
+      } catch {}
     }
 
     this._hooks[name] = this._hooks[name] || [];

--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -74,7 +74,7 @@ export class Hookable<
     // Add name to hook for better debugging experience
     if (!function_.name) {
       Object.defineProperty(function_, "name", {
-        get: () => name + " callback",
+        get: () => '_' + name.replace(/\W+/g, '_') + "_hook_cb",
         configurable: true,
       });
     }

--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -71,6 +71,11 @@ export class Hookable<
       }
     }
 
+    // Add name to hook for better debugging experience
+    if (!function_.name) {
+      Object.defineProperty(function_, 'name', { get: () => name + ' callback' })
+    }
+
     this._hooks[name] = this._hooks[name] || [];
     this._hooks[name].push(function_);
 


### PR DESCRIPTION
This names anonymous functions after the hook they are called in if they do not already have a name. This is a pure DX improvement, so that we don't have `(anonymous)` in stack traces.