### PR TITLE
feat: use `console.createTask` to improve traces where supported

### DIFF
--- a/shims.d.ts
+++ b/shims.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  // eslint-disable-next-line no-unused-vars
+  interface Console {
+    createTask(name: string): { run: <T extends () => any>(function_: T) => ReturnType<T> }
+  }
+}
+
+export {};

--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -194,7 +194,7 @@ export class Hookable<
     if (this._before) {
       callEachWith(this._before, event);
     }
-    const result = caller(this._hooks[name] || [], arguments_);
+    const result = caller.call({ name }, this._hooks[name] || [], arguments_);
     if ((result as any) instanceof Promise) {
       return result.finally(() => {
         if (this._after && event) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,16 +56,26 @@ export function serial<T>(
   );
 }
 
+type Task = ReturnType<typeof console.createTask>;
+const defaultTask = { run: (function_) => function_() } as Task;
+const createTask =
+  typeof console.createTask !== "undefined"
+    ? console.createTask
+    : () => defaultTask;
+
 export function serialCaller(hooks: HookCallback[], arguments_?: any[]) {
+  const task = createTask(this.name);
   // eslint-disable-next-line unicorn/no-array-reduce
   return hooks.reduce(
-    (promise, hookFunction) => promise.then(() => hookFunction(...arguments_)),
+    (promise, hookFunction) =>
+      promise.then(() => task.run(() => hookFunction(...arguments_))),
     Promise.resolve()
   );
 }
 
 export function parallelCaller(hooks: HookCallback[], arguments_?: any[]) {
-  return Promise.all(hooks.map((hook) => hook(...arguments_)));
+  const task = createTask(this.name);
+  return Promise.all(hooks.map((hook) => task.run(() => hook(...arguments_))));
 }
 
 export function callEachWith(


### PR DESCRIPTION
**More info**: https://developer.chrome.com/blog/devtools-modern-web-debugging/#linked-stack-traces

This has relatively low support at the moment outside of Chromium browsers. Node support is available in Node 19+: https://github.com/nodejs/node/issues/44792.

However, it is a very nice DX improvement where supported.

| Before | After |
| - | - |
| ![CleanShot 2023-03-09 at 15 04 42](https://user-images.githubusercontent.com/28706372/224065463-b58a8469-7769-4bf7-b54c-119cf6dc1856.png) | ![CleanShot 2023-03-09 at 15 03 44](https://user-images.githubusercontent.com/28706372/224065521-4c191ace-46c6-4813-8207-bbc0e2fe9e0f.png) |

**Note** that the remaining anonymous functions in the stack trace will be named if/when https://github.com/unjs/hookable/pull/68 merges.

I've made use of a fictitious `this` to pass the hook name to callers in a non-breaking fashion, but other ideas are very welcome.