### PR TITLE
docs: add `removeAllHooks` and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,16 @@ hookable.removeHooks({
 })
 ```
 
+### `removeAllHooks`
+
+Remove all hook handlers.
+
 ### `beforeEach (syncCallback)`
 
 Registers a (sync) callback to be called before each hook is being called.
 
 ```js
-hookable.beforeEach((event) => { console.log(`${event.name} hook is being called with ${event.args}`)})
+hookable.beforeEach((event) => { console.log(`${event.name} hook is being called with ${event.args}`)}`)
 hookable.hook('test', () => { console.log('running test hook') })
 
 // test hook is being called with []
@@ -212,7 +216,7 @@ await hookable.callHook('test')
 Registers a (sync) callback to be called after each hook is being called.
 
 ```js
-hookable.afterEach((event) => { console.log(`${event.name} hook called with ${event.args}`)})
+hookable.afterEach((event) => { console.log(`${event.name} hook called with ${event.args}`)}`)
 hookable.hook('test', () => { console.log('running test hook') })
 
 // running test hook


### PR DESCRIPTION
I just added description about `removeAllHooks` (#61) and fixed typos in code blocks.