### PR TITLE
chore(lint): fix formatting

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -43,7 +43,8 @@ export function createDebugger(
       : _filter;
 
   const _tag = options.tag ? `[${options.tag}] ` : "";
-  const logPrefix = (event: any) => _tag + event.name + "".padEnd(event._id, "\0");
+  const logPrefix = (event: any) =>
+    _tag + event.name + "".padEnd(event._id, "\0");
 
   const _idCtr: Record<string, number> = {};
 

--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -103,7 +103,9 @@ export class Hookable<
     function_: InferCallback<HooksT, NameT>
   ) {
     let _unreg: (() => void) | undefined;
-    let _function: ((...arguments_: any) => any) | undefined = (...arguments_: any) => {
+    let _function: ((...arguments_: any) => any) | undefined = (
+      ...arguments_: any
+    ) => {
       if (typeof _unreg === "function") {
         _unreg();
       }
@@ -246,7 +248,7 @@ export class Hookable<
   }
 
   afterEach(function_: (event: InferSpyEvent<HooksT>) => void) {
-    this._after = (this._after || []);
+    this._after = this._after || [];
     this._after.push(function_);
     return () => {
       if (this._after !== undefined) {


### PR DESCRIPTION
Personally I think Prettier formatting is bonkers but this is what it did.

I hope a new version can be released with the type fix after this is fixed.