### PR TITLE
fix: await thenables to support cross-realm promises

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,8 +80,9 @@ export function callHooks(
   for (let i = startIndex; i < hooks.length; i += 1) {
     try {
       const result = task ? task.run(() => hooks[i](...args)) : hooks[i](...args);
-      if (result instanceof Promise) {
-        return result.then(() => callHooks(hooks, args, i + 1, task));
+      // Use thenable check to support cross-realm Promises (e.g. from vm/jiti).
+      if (result && typeof (result as any).then === "function") {
+        return Promise.resolve(result).then(() => callHooks(hooks, args, i + 1, task));
       }
     } catch (error) {
       return Promise.reject(error);

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -26,7 +26,7 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log("new HookableCore():", { bytes, gzipSize });
     }
-    expect(bytes).toBeLessThan(641);
+    expect(bytes).toBeLessThan(642);
     expect(gzipSize).toBeLessThan(370);
   });
 });

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -26,7 +26,7 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log("new HookableCore():", { bytes, gzipSize });
     }
-    expect(bytes).toBeLessThan(630);
+    expect(bytes).toBeLessThan(641);
     expect(gzipSize).toBeLessThan(370);
   });
 });

--- a/test/hookable.test.ts
+++ b/test/hookable.test.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import vm from "node:vm";
 import { describe, test, beforeEach, expect, vi } from "vitest";
 import { Hookable, HookableCore, flatHooks, mergeHooks } from "../src/index.ts";
 
@@ -439,5 +440,41 @@ describe("hookable", () => {
     };
     await hooks.callHookWith(customSerialCaller, "test");
     expect(result).toBe(3);
+  });
+
+  // Regression: https://github.com/nitrojs/nitro/issues/4203
+  // Cross-realm Promises (e.g. from jiti/vm) fail `instanceof Promise`,
+  // so hookable must detect thenables and await them regardless.
+  test("awaits cross-realm thenables returned by async hooks", async () => {
+    const context = vm.createContext({});
+    const foreignAsync = vm.runInContext(
+      `(async (obj) => { await Promise.resolve(); obj.called = true; })`,
+      context,
+    );
+
+    const probe = foreignAsync({ called: false });
+    expect(typeof probe.then).toBe("function");
+    expect(probe instanceof Promise).toBe(false);
+
+    const hooks = new Hookable();
+    hooks.hook("test", foreignAsync);
+
+    const obj = { called: false };
+    await hooks.callHook("test", obj);
+    expect(obj.called).toBe(true);
+
+    // Also verify the next hook runs *after* the foreign thenable settles.
+    const order: string[] = [];
+    const foreignOrderedAsync = vm.runInContext(
+      `(async (arr) => { await Promise.resolve(); await Promise.resolve(); arr.push("first"); })`,
+      context,
+    );
+    const hooks2 = new Hookable();
+    hooks2.hook("t", foreignOrderedAsync);
+    hooks2.hook("t", (arr: string[]) => {
+      arr.push("second");
+    });
+    await hooks2.callHook("t", order);
+    expect(order).toEqual(["first", "second"]);
   });
 });


### PR DESCRIPTION
 Replace `result instanceof Promise` with a thenable check (`typeof result.then === "function"`) in `callHooks`, so hooks returning a Promise from a different realm (e.g. jiti/vm contexts) are awaited correctly instead of silently dropped.


Reported by @brandonroberts in nitrojs/nitro#4203 ❤️ 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of asynchronous results from external or sandboxed execution contexts so async operations are reliably detected and awaited, preserving correct execution order.
* **Tests**
  * Added a regression test covering cross-context async behavior and adjusted a bundle-size benchmark to reflect updated measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->