### PR TITLE
fix: always call timeEnd after timeLog in createDebugger when inspect is true

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -68,9 +68,8 @@ export function createDebugger(
     }
     if (options.inspect) {
       console.timeLog(logPrefix(event), event.args);
-    } else {
-      console.timeEnd(logPrefix(event));
     }
+    console.timeEnd(logPrefix(event));
     if (options.group) {
       console.groupEnd();
     }

--- a/test/debuger.test.ts
+++ b/test/debuger.test.ts
@@ -51,6 +51,18 @@ describe("debugger", () => {
     await hooks.callHook("other:hook");
     expect(console.time).toBeCalled();
   });
+  it("should end timer when inspect is true", async () => {
+    createDebugger(hooks, { inspect: true });
+    await hooks.callHook("hook");
+    expect(console.timeEnd).toBeCalledWith(expect.stringContaining("hook"));
+  });
+  it("should not leak timers when calling same hook twice with inspect", async () => {
+    createDebugger(hooks, { inspect: true });
+    await hooks.callHook("hook");
+    await hooks.callHook("hook");
+    expect(console.time).toBeCalledTimes(2);
+    expect(console.timeEnd).toBeCalledTimes(2);
+  });
   it("should allowing closing debugger", async () => {
     const debug = createDebugger(hooks);
     await hooks.callHook("hook");


### PR DESCRIPTION
## What does this PR fix?

`createDebugger` in `src/debugger.ts` calls `console.timeLog()` in the 
`afterEach` handler when `inspect: true` but never calls `console.timeEnd()`. 
This causes every hook call to leak a console timer. On the second call to 
the same hook the browser warns:

> Timer 'hookName' already exists

Since `inspect` defaults to `true` in browsers, every browser user of 
`createDebugger` is affected.

## Root cause

`console.timeEnd()` was inside the `else` branch of the `inspect` check, 
so it was never reached when `inspect: true`. The timer started by 
`console.time()` in `beforeEach` was never ended.

## Fix

Moved `console.timeEnd()` outside the `if/else` block so it always runs 
regardless of `inspect` value. `console.timeLog()` still only runs when 
`inspect: true`.

**Before:**
```ts
if (options.inspect) {
  console.timeLog(logPrefix(event), event.args)
} else {
  console.timeEnd(logPrefix(event))
}
```

**After:**
```ts
if (options.inspect) {
  console.timeLog(logPrefix(event), event.args)
}
console.timeEnd(logPrefix(event))
```

## Tests added

- `should end timer when inspect is true` — asserts `console.timeEnd` 
  is called with the hook label
- `should not leak timers when calling same hook twice with inspect` — 
  asserts `console.time` and `console.timeEnd` are each called exactly 
  twice with no leaked timers

Fixes #142

> Developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timer lifecycle management in the debugger. Timer cleanup now executes consistently regardless of inspection mode settings.

* **Tests**
  * Added validation tests for timer behavior during debugging operations to ensure timers properly initialize and terminate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/hookable/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->