### PR TITLE
fix: fallback when console.createTask returns undefined

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,11 +63,12 @@ declare global {
   }
 }
 
+const defaultTask: ReturnType<CreateTask> = { run: (function_) => function_() };
+
 const createTask = /* @__PURE__ */ (() => {
   if (console.createTask) {
-    return console.createTask;
+    return (name?: string) => console.createTask!(name) ?? defaultTask;
   }
-  const defaultTask: ReturnType<CreateTask> = { run: (fn) => fn() };
   return () => defaultTask;
 })();
 

--- a/test/hookable.test.ts
+++ b/test/hookable.test.ts
@@ -477,4 +477,20 @@ describe("hookable", () => {
     await hooks2.callHook("t", order);
     expect(order).toEqual(["first", "second"]);
   });
+
+  test("falls back when console.createTask returns undefined", async () => {
+    const originalCreateTask = console.createTask;
+    console.createTask = () => undefined as any;
+
+    try {
+      const hook = new Hookable();
+      hook.hook("test", () => {});
+      expect(() => hook.callHook("test")).not.toThrow();
+
+      hook.hook("parallel", () => {});
+      await expect(hook.callHookParallel("parallel")).resolves.toEqual([undefined]);
+    } finally {
+      console.createTask = originalCreateTask;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Wrap `console.createTask` so a missing/undefined task falls back to a no-op runner
- Prevents `Cannot read properties of undefined (reading 'run')` in serial and parallel hook callers

## Example

```js
console.createTask = () => undefined;
const hooks = new Hookable();
hooks.hook("test", () => {});
hooks.callHook("test"); // no longer throws
```

Fixes #114

## Test plan

- [x] Added regression test for undefined `console.createTask` return value
- [x] `pnpm exec vitest run` — 44 passing
- [x] `pnpm lint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback behavior in task creation to properly handle undefined values and edge cases.

* **Tests**
  * Added regression test to verify system stability when task creation encounters specific conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/hookable/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->