### PR TITLE
feat: return removed hooks from remove* methods

### DIFF
--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -111,24 +111,33 @@ export class Hookable<
     return _unreg;
   }
 
-  removeHook<NameT extends HookNameT>(name: NameT, function_: InferCallback<HooksT, NameT>): void {
+  removeHook<NameT extends HookNameT>(
+    name: NameT,
+    function_: InferCallback<HooksT, NameT>,
+  ): InferCallback<HooksT, NameT> | undefined {
     const hooks = this._hooks[name];
 
     if (hooks) {
       const index = hooks.indexOf(function_);
 
       if (index !== -1) {
-        hooks.splice(index, 1);
-      }
+        const [removed] = hooks.splice(index, 1);
 
-      if (hooks.length === 0) {
-        this._hooks[name] = undefined;
+        if (hooks.length === 0) {
+          this._hooks[name] = undefined;
+        }
+
+        return removed as InferCallback<HooksT, NameT>;
       }
     }
+
+    return undefined;
   }
 
-  clearHook<NameT extends HookNameT>(name: NameT): void {
+  clearHook<NameT extends HookNameT>(name: NameT): InferCallback<HooksT, NameT>[] {
+    const hooks = this._hooks[name] ? [...this._hooks[name]!] : [];
     this._hooks[name] = undefined;
+    return hooks as InferCallback<HooksT, NameT>[];
   }
 
   deprecateHook<NameT extends HookNameT>(
@@ -165,16 +174,29 @@ export class Hookable<
     };
   }
 
-  removeHooks(configHooks: NestedHooks<HooksT>): void {
+  removeHooks(configHooks: NestedHooks<HooksT>): InferCallback<HooksT, HookNameT>[] {
     const hooks = flatHooks<HooksT>(configHooks);
+    const removed: InferCallback<HooksT, HookNameT>[] = [];
     for (const key in hooks) {
       // @ts-ignore
-      this.removeHook(key, hooks[key]);
+      const hook = this.removeHook(key, hooks[key]);
+      if (hook) {
+        removed.push(hook);
+      }
     }
+    return removed;
   }
 
-  removeAllHooks(): void {
+  removeAllHooks(): Record<string, InferCallback<HooksT, HookNameT>[]> {
+    const snapshot: Record<string, InferCallback<HooksT, HookNameT>[]> = {};
+    for (const name in this._hooks) {
+      const hooks = this._hooks[name];
+      if (hooks?.length) {
+        snapshot[name] = [...hooks] as InferCallback<HooksT, HookNameT>[];
+      }
+    }
     this._hooks = {};
+    return snapshot;
   }
 
   callHook<NameT extends HookNameT>(
@@ -281,20 +303,27 @@ export class HookableCore<
     };
   }
 
-  removeHook<NameT extends HookNameT>(name: NameT, function_: InferCallback<HooksT, NameT>): void {
+  removeHook<NameT extends HookNameT>(
+    name: NameT,
+    function_: InferCallback<HooksT, NameT>,
+  ): InferCallback<HooksT, NameT> | undefined {
     const hooks = this._hooks[name];
 
     if (hooks) {
       const index = hooks.indexOf(function_);
 
       if (index !== -1) {
-        hooks.splice(index, 1);
-      }
+        const [removed] = hooks.splice(index, 1);
 
-      if (hooks.length === 0) {
-        this._hooks[name] = undefined;
+        if (hooks.length === 0) {
+          this._hooks[name] = undefined;
+        }
+
+        return removed as InferCallback<HooksT, NameT>;
       }
     }
+
+    return undefined;
   }
 
   callHook<NameT extends HookNameT>(

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -13,8 +13,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log("new Hookable():", { bytes, gzipSize });
     }
-    expect(bytes).toBeLessThan(3000);
-    expect(gzipSize).toBeLessThan(1200);
+    expect(bytes).toBeLessThan(3250);
+    expect(gzipSize).toBeLessThan(1260);
   });
 
   it("new HookableCore()", async () => {
@@ -26,8 +26,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log("new HookableCore():", { bytes, gzipSize });
     }
-    expect(bytes).toBeLessThan(642);
-    expect(gzipSize).toBeLessThan(370);
+    expect(bytes).toBeLessThan(680);
+    expect(gzipSize).toBeLessThan(385);
   });
 });
 

--- a/test/hookable.test.ts
+++ b/test/hookable.test.ts
@@ -306,7 +306,38 @@ describe("hookable", () => {
 
   test("clearHook should be safe to call for non-existent hooks", () => {
     const hook = new Hookable();
-    expect(() => hook.clearHook("test:nonexistent")).not.toThrow();
+    expect(hook.clearHook("test:nonexistent")).toEqual([]);
+  });
+
+  test("remove methods should return removed hooks", () => {
+    const hook = new Hookable();
+    const callback = () => {};
+    const before = () => {};
+
+    hook.hook("test:hook", callback);
+    hook.hook("test:before", before);
+
+    expect(hook.removeHook("test:hook", callback)).toBe(callback);
+    expect(hook.removeHook("test:missing", callback)).toBeUndefined();
+
+    hook.hook("test:hook", callback);
+    expect(hook.clearHook("test:hook")).toEqual([callback]);
+    expect(hook._hooks["test:hook"]).toBeUndefined();
+
+    hook.clearHook("test:before");
+    hook.hook("test:hook", callback);
+    hook.hook("test:before", before);
+    expect(hook.removeHooks({ test: { hook: callback, before } })).toEqual([callback, before]);
+    expect(hook._hooks["test:hook"]).toBeUndefined();
+    expect(hook._hooks["test:before"]).toBeUndefined();
+
+    hook.hook("test:hook", callback);
+    hook.hook("test:before", before);
+    expect(hook.removeAllHooks()).toEqual({
+      "test:hook": [callback],
+      "test:before": [before],
+    });
+    expect(hook._hooks).toEqual({});
   });
 
   test("should clear only the hooks added by addHooks", () => {


### PR DESCRIPTION
## Summary

- `removeHook` returns the removed callback (or `undefined` if not found)
- `clearHook` returns a copy of all cleared handlers for that name
- `removeHooks` returns an array of removed callbacks
- `removeAllHooks` returns a snapshot of all registered hooks before clearing

This enables reordering or re-registering hooks after removal, as requested for Nuxt integration.

Fixes #113

## Test plan

- [x] Added test covering return values for all `remove*` methods
- [x] Updated bundle size thresholds for the small increase
- [x] `pnpm test` (44 tests pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Hook removal methods now return the removed hook functions and snapshots instead of void, giving developers programmatic access to removed callbacks for better lifecycle management.

* **Tests**
  * Updated bundle size benchmarks to reflect API enhancements.
  * Added comprehensive tests verifying hook removal return values and internal state cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/hookable/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->