### PR TITLE
feat: add callHookOnce to clear listeners after calling

### DIFF
--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -191,6 +191,23 @@ export class Hookable<
     return this.callHookWith(parallelTaskCaller, name, args);
   }
 
+  callHookOnce<NameT extends HookNameT>(
+    name: NameT,
+    ...args: Parameters<InferCallback<HooksT, NameT>>
+  ): Promise<any> | void {
+    const result = this.callHook(name, ...args);
+    const clear = () => {
+      this.clearHook(name);
+    };
+
+    if (result && typeof (result as Promise<any>).then === "function") {
+      return Promise.resolve(result).finally(clear);
+    }
+
+    clear();
+    return result;
+  }
+
   callHookWith<
     NameT extends HookNameT,
     CallFunction extends (

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -13,8 +13,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log("new Hookable():", { bytes, gzipSize });
     }
-    expect(bytes).toBeLessThan(3000);
-    expect(gzipSize).toBeLessThan(1200);
+    expect(bytes).toBeLessThan(3200);
+    expect(gzipSize).toBeLessThan(1230);
   });
 
   it("new HookableCore()", async () => {

--- a/test/hookable.test.ts
+++ b/test/hookable.test.ts
@@ -427,6 +427,42 @@ describe("hookable", () => {
     expect(result).toBe(3);
   });
 
+  test("callHookOnce clears listeners after calling", async () => {
+    const hook = new Hookable();
+    let count = 0;
+
+    hook.hook("test", () => {
+      count++;
+    });
+    hook.hook("test", () => {
+      count++;
+    });
+
+    await hook.callHookOnce("test");
+    expect(count).toBe(2);
+    expect(hook._hooks.test).toBeUndefined();
+
+    await hook.callHook("test");
+    expect(count).toBe(2);
+  });
+
+  test("callHookOnce clears listeners after async hooks complete", async () => {
+    const hook = new Hookable();
+    let count = 0;
+
+    hook.hook("test", async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      count++;
+    });
+
+    await hook.callHookOnce("test");
+    expect(count).toBe(1);
+    expect(hook._hooks.test).toBeUndefined();
+
+    await hook.callHook("test");
+    expect(count).toBe(1);
+  });
+
   test("callEachWith", async () => {
     let result = 0;
     const hooks = new Hookable();


### PR DESCRIPTION
## Summary

- Adds `callHookOnce(name, ...args)` to call a hook and then `clearHook(name)` so all listeners are discarded from the provider side
- For async hooks, clearing happens in `finally` after the returned promise settles
- Updates bundle size limits (+149B minified, +41B gzipped)

Closes #105

## Test plan

- [x] `pnpm test` (lint + 45 vitest tests including sync/async `callHookOnce` cases)