### PR TITLE
feat: add clone to duplicate Hookable instances

### DIFF
--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -177,6 +177,30 @@ export class Hookable<
     this._hooks = {};
   }
 
+  clone(): Hookable<HooksT> {
+    const cloned = new Hookable<HooksT>();
+
+    for (const name in this._deprecatedHooks) {
+      cloned.deprecateHook(
+        name as HookNameT,
+        this._deprecatedHooks[name] as DeprecatedHook<HooksT>,
+      );
+    }
+
+    for (const name in this._hooks) {
+      const hooks = this._hooks[name];
+      if (hooks) {
+        for (const fn of hooks) {
+          cloned.hook(name as HookNameT, fn as InferCallback<HooksT, HookNameT>, {
+            allowDeprecated: true,
+          });
+        }
+      }
+    }
+
+    return cloned;
+  }
+
   callHook<NameT extends HookNameT>(
     name: NameT,
     ...args: Parameters<InferCallback<HooksT, NameT>>

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -13,8 +13,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log("new Hookable():", { bytes, gzipSize });
     }
-    expect(bytes).toBeLessThan(3000);
-    expect(gzipSize).toBeLessThan(1200);
+    expect(bytes).toBeLessThan(3250);
+    expect(gzipSize).toBeLessThan(1240);
   });
 
   it("new HookableCore()", async () => {

--- a/test/hookable.test.ts
+++ b/test/hookable.test.ts
@@ -348,6 +348,36 @@ describe("hookable", () => {
     expect(x).toBe(1);
   });
 
+  test("clone creates independent copy of hooks", async () => {
+    const hook = new Hookable();
+    let count = 0;
+
+    hook.hook("test", () => {
+      count++;
+    });
+
+    const cloned = hook.clone();
+
+    hook.hook("test", () => {
+      count++;
+    });
+    cloned.hook("other", () => {
+      count++;
+    });
+
+    await hook.callHook("test");
+    expect(count).toBe(2);
+
+    await cloned.callHook("test");
+    expect(count).toBe(3);
+
+    await cloned.callHook("other");
+    expect(count).toBe(4);
+
+    await hook.callHook("other");
+    expect(count).toBe(4);
+  });
+
   test("hook sync", () => {
     const hook = new Hookable();
 


### PR DESCRIPTION
## Summary

- Adds `clone()` to create a new `Hookable` instance with the same registered hooks and deprecation mappings
- Cloned instances are independent: adding hooks to one does not affect the other

Closes #116

## Test plan

- [x] `pnpm test` (44 tests)
- [x] Verified clone preserves hooks and mutations stay isolated between instances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `clone()` method to Hookable, enabling you to create independent copies of hook instances with all registered hooks preserved.

* **Tests**
  * Added test coverage for clone functionality to verify independence of cloned instances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/hookable/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->