### PR TITLE
feat: add enforce option to hook() for before/after ordering

### DIFF
--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -43,7 +43,7 @@ export class Hookable<
   hook<NameT extends HookNameT>(
     name: NameT,
     function_: InferCallback<HooksT, NameT>,
-    options: { allowDeprecated?: boolean } = {},
+    options: { allowDeprecated?: boolean; enforce?: "before" | "after" } = {},
   ): () => void {
     if (!name || typeof function_ !== "function") {
       return () => {};
@@ -83,7 +83,11 @@ export class Hookable<
     }
 
     this._hooks[name] = this._hooks[name] || [];
-    this._hooks[name]!.push(function_);
+    if (options.enforce === "before") {
+      this._hooks[name]!.unshift(function_);
+    } else {
+      this._hooks[name]!.push(function_);
+    }
 
     return () => {
       if (function_) {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -13,8 +13,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log("new Hookable():", { bytes, gzipSize });
     }
-    expect(bytes).toBeLessThan(3000);
-    expect(gzipSize).toBeLessThan(1200);
+    expect(bytes).toBeLessThan(3100);
+    expect(gzipSize).toBeLessThan(1220);
   });
 
   it("new HookableCore()", async () => {

--- a/test/hookable.test.ts
+++ b/test/hookable.test.ts
@@ -41,6 +41,44 @@ describe("hookable", () => {
     expect(hook._hooks["test:hook"]).toEqual([expect.any(Function), expect.any(Function)]);
   });
 
+  test("hook with enforce before runs before previously registered hooks", async () => {
+    const hook = new Hookable();
+    const order: string[] = [];
+
+    hook.hook("test", () => {
+      order.push("first");
+    });
+    hook.hook(
+      "test",
+      () => {
+        order.push("second");
+      },
+      { enforce: "before" },
+    );
+
+    await hook.callHook("test");
+    expect(order).toEqual(["second", "first"]);
+  });
+
+  test("hook with enforce after runs after previously registered hooks", async () => {
+    const hook = new Hookable();
+    const order: string[] = [];
+
+    hook.hook("test", () => {
+      order.push("first");
+    });
+    hook.hook(
+      "test",
+      () => {
+        order.push("second");
+      },
+      { enforce: "after" },
+    );
+
+    await hook.callHook("test");
+    expect(order).toEqual(["first", "second"]);
+  });
+
   test("should ignore empty hook name", () => {
     const hook = new Hookable();
     hook.hook(0, () => {});


### PR DESCRIPTION
## Summary

- Add optional `enforce: 'before' | 'after'` to `hook()` options
- When `enforce: 'before'`, listener is inserted at the front of the hook queue (instead of requiring manual `_hooks` unshift workaround)
- Default behavior unchanged (`after` / append to queue)

Fixes #98

## Test plan

- [x] Added tests for `enforce: 'before'` and `enforce: 'after'` execution order
- [x] Updated bundle size limits (3043 bytes / 1207 gzip)
- [x] `pnpm test` passes (45 tests)