### PR TITLE
feat: add onHook spy for listener registration events

### DIFF
--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -16,6 +16,12 @@ type InferSpyEvent<HT extends Record<string, any>> = {
     context: Record<string, any>;
   };
 }[keyof HT];
+type InferHookRegisterEvent<HT extends Record<string, any>> = {
+  [key in keyof HT]: {
+    name: key;
+    hook: HT[key];
+  };
+}[keyof HT];
 
 export class Hookable<
   HooksT extends Record<string, any> = Record<string, HookCallback>,
@@ -24,6 +30,7 @@ export class Hookable<
   private _hooks: { [key: string]: HookCallback[] | undefined };
   private _before?: HookCallback[];
   private _after?: HookCallback[];
+  private _onHook?: HookCallback[];
   private _deprecatedHooks: Record<string, DeprecatedHook<HooksT>>;
   private _deprecatedMessages?: Set<string>;
 
@@ -31,6 +38,7 @@ export class Hookable<
     this._hooks = {};
     this._before = undefined;
     this._after = undefined;
+    this._onHook = undefined;
     this._deprecatedMessages = undefined;
     this._deprecatedHooks = {};
 
@@ -84,6 +92,10 @@ export class Hookable<
 
     this._hooks[name] = this._hooks[name] || [];
     this._hooks[name]!.push(function_);
+
+    if (this._onHook) {
+      callEachWith(this._onHook, { name, hook: function_ });
+    }
 
     return () => {
       if (function_) {
@@ -246,6 +258,19 @@ export class Hookable<
         const index = this._after.indexOf(function_);
         if (index !== -1) {
           this._after.splice(index, 1);
+        }
+      }
+    };
+  }
+
+  onHook(function_: (event: InferHookRegisterEvent<HooksT>) => void): () => void {
+    this._onHook = this._onHook || [];
+    this._onHook.push(function_);
+    return () => {
+      if (this._onHook !== undefined) {
+        const index = this._onHook.indexOf(function_);
+        if (index !== -1) {
+          this._onHook.splice(index, 1);
         }
       }
     };

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -13,8 +13,8 @@ describe("benchmark", () => {
     if (process.env.DEBUG) {
       console.log("new Hookable():", { bytes, gzipSize });
     }
-    expect(bytes).toBeLessThan(3000);
-    expect(gzipSize).toBeLessThan(1200);
+    expect(bytes).toBeLessThan(3250);
+    expect(gzipSize).toBeLessThan(1240);
   });
 
   it("new HookableCore()", async () => {

--- a/test/hookable.test.ts
+++ b/test/hookable.test.ts
@@ -397,6 +397,29 @@ describe("hookable", () => {
     expect(x).toBe(5);
   });
 
+  test("onHook spy", () => {
+    const hook = new Hookable<{ test(): void; other(): void }>();
+    const events: Array<{ name: string; hook: () => void }> = [];
+
+    const unreg = hook.onHook((event) => {
+      events.push({ name: event.name, hook: event.hook });
+    });
+
+    const testHook = () => {};
+    const otherHook = () => {};
+    hook.hook("test", testHook);
+    hook.hook("other", otherHook);
+
+    expect(events).toEqual([
+      { name: "test", hook: testHook },
+      { name: "other", hook: otherHook },
+    ]);
+
+    unreg();
+    hook.hook("test", () => {});
+    expect(events).toHaveLength(2);
+  });
+
   test("mergeHooks", () => {
     const function_ = () => {};
     const hooks1 = {

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -88,4 +88,23 @@ describe("hook types", () => {
       }
     });
   });
+
+  test("onHook typings", () => {
+    const hooks = createHooks<{
+      foo: () => true;
+      bar: (_arg: number) => 42;
+    }>();
+
+    expectTypeOf(hooks.onHook)
+      .parameter(0)
+      .parameter(0)
+      .toEqualTypeOf<
+        { name: "foo"; hook: () => true } | { name: "bar"; hook: (_arg: number) => 42 }
+      >();
+
+    hooks.onHook(({ name, hook }) => {
+      expectTypeOf(name).toEqualTypeOf<"foo" | "bar">();
+      expectTypeOf(hook).toBeFunction();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add `onHook()` spy API to observe when listeners are registered via `hook()`
- Event payload includes resolved hook name (after deprecation aliasing) and the registered callback
- Supports unregister via returned cleanup function, matching `beforeEach` / `afterEach` pattern

Fixes #117

## Example

```ts
const hooks = createHooks<{ "app:user:registered": () => void }>();

hooks.onHook(({ name, hook }) => {
  console.log(`hook listener ${String(name)} (listen)`);
});

hooks.hook("app:user:registered", () => {});
```

## Test plan

- [x] Added runtime test for `onHook` registration events and unregister
- [x] Added TypeScript type tests for `onHook` event payload
- [x] Updated bundle size limits (3234 bytes / 1235 gzip)
- [x] `pnpm test` passes (45 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced hook registration observers. Register listeners that receive notifications whenever hooks are registered, including their names and function references.

* **Tests**
  * Added comprehensive tests validating observer functionality, event payloads, deregistration behavior, and type-safe callback parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/hookable/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->