### PR TITLE
feat: add callHookChained and chainableTaskCaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ If you need custom control over how hooks are called, you can provide a custom f
 - `args`: Array of arguments that should be passed each time calling a hook
 - `name`: Name of the hook
 
+### `callHookChained (name, initialValue)`
+
+Sequentially call hooks, passing the return value of each hook as the sole argument to the next. Returns the final value (or the initial value if no hooks are registered).
+
+You can also use the exported `chainableTaskCaller` with `callHookWith` for custom chaining behavior.
+
 ### `deprecateHook (old, name)`
 
 Deprecate hook called `old` in favor of `name` hook.

--- a/src/hookable.ts
+++ b/src/hookable.ts
@@ -2,6 +2,7 @@ import {
   flatHooks,
   parallelTaskCaller,
   serialTaskCaller,
+  chainableTaskCaller,
   callEachWith,
   callHooks,
 } from "./utils.ts";
@@ -38,6 +39,7 @@ export class Hookable<
     this.hook = this.hook.bind(this);
     this.callHook = this.callHook.bind(this);
     this.callHookWith = this.callHookWith.bind(this);
+    this.callHookChained = this.callHookChained.bind(this);
   }
 
   hook<NameT extends HookNameT>(
@@ -189,6 +191,13 @@ export class Hookable<
     ...args: Parameters<InferCallback<HooksT, NameT>>
   ): Promise<any[]> | void {
     return this.callHookWith(parallelTaskCaller, name, args);
+  }
+
+  callHookChained<NameT extends HookNameT, ValueT>(
+    name: NameT,
+    initial: ValueT,
+  ): Promise<ValueT> | ValueT {
+    return this.callHookWith(chainableTaskCaller, name, [initial] as any);
   }
 
   callHookWith<

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,13 @@
 export { Hookable, HookableCore, createHooks } from "./hookable.ts";
 
-export { flatHooks, mergeHooks, parallelCaller, serial, serialCaller } from "./utils.ts";
+export {
+  flatHooks,
+  mergeHooks,
+  parallelCaller,
+  serial,
+  serialCaller,
+  chainableTaskCaller,
+} from "./utils.ts";
 
 export * from "./debugger.ts";
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,6 +111,35 @@ export function parallelTaskCaller(
   }
 }
 
+export function chainableTaskCaller(
+  hooks: HookCallback[],
+  args: any[],
+  name: string,
+): Promise<any> | any {
+  if (hooks.length === 0) {
+    return args[0];
+  }
+
+  const task = createTask(name);
+
+  function runFrom(index: number, value: any): Promise<any> | any {
+    if (index >= hooks.length) {
+      return value;
+    }
+    try {
+      const hookResult = task.run(() => hooks[index](value));
+      if (hookResult && typeof (hookResult as any).then === "function") {
+        return Promise.resolve(hookResult).then((next) => runFrom(index + 1, next));
+      }
+      return runFrom(index + 1, hookResult);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+
+  return runFrom(0, args[0]);
+}
+
 /** @deprecated */
 export function serialCaller(hooks: HookCallback[], arguments_?: any[]): Promise<any> {
   // eslint-disable-next-line unicorn/no-array-reduce

--- a/test/hookable.test.ts
+++ b/test/hookable.test.ts
@@ -442,6 +442,30 @@ describe("hookable", () => {
     expect(result).toBe(3);
   });
 
+  test("callHookChained passes result through hooks", () => {
+    const hooks = new Hookable();
+    hooks.hook("transform", (value: number) => value + 1);
+    hooks.hook("transform", (value: number) => value * 2);
+
+    expect(hooks.callHookChained("transform", 1)).toBe(4);
+  });
+
+  test("callHookChained returns initial value when no hooks registered", () => {
+    const hooks = new Hookable();
+    expect(hooks.callHookChained("missing", { ok: true })).toEqual({ ok: true });
+  });
+
+  test("chainableTaskCaller supports async hooks", async () => {
+    const hooks = new Hookable();
+    hooks.hook("transform", async (value: number) => {
+      await Promise.resolve();
+      return value + 1;
+    });
+    hooks.hook("transform", (value: number) => value * 3);
+
+    await expect(hooks.callHookChained("transform", 2)).resolves.toBe(9);
+  });
+
   // Regression: https://github.com/nitrojs/nitro/issues/4203
   // Cross-realm Promises (e.g. from jiti/vm) fail `instanceof Promise`,
   // so hookable must detect thenables and await them regardless.


### PR DESCRIPTION
## Summary

- Export `chainableTaskCaller` for use with `callHookWith`
- Add `callHookChained(name, initialValue)` to sequentially pass each hook's return value as the next hook's input
- Supports sync and async hooks (thenable-safe, consistent with existing callers)

Closes #111

## Test plan

- [x] Added tests for sync chaining, async chaining, and empty hook lists
- [x] `pnpm lint` passes
- [x] `pnpm vitest run test/hookable.test.ts test/debuger.test.ts` passes (39/39)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new method for sequential hook execution where each registered hook receives the previous hook's returned value as input, with the final result returned to the caller.

* **Documentation**
  * Updated documentation with comprehensive details on the new sequential hook execution feature.

* **Tests**
  * Added test coverage for sequential hook execution including both synchronous and asynchronous hook scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/hookable/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->