### PR TITLE
fix(debugger): call console.timeEnd when inspect is true to prevent timer leak

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -68,9 +68,8 @@ export function createDebugger(
     }
     if (options.inspect) {
       console.timeLog(logPrefix(event), event.args);
-    } else {
-      console.timeEnd(logPrefix(event));
     }
+    console.timeEnd(logPrefix(event));
     if (options.group) {
       console.groupEnd();
     }


### PR DESCRIPTION
## Summary

Fixes a timer leak in `createDebugger` when `inspect: true` (the browser default) — `console.time()` was started in `beforeEach` but `console.timeEnd()` was never called in `afterEach`.

## Changes

- `src/debugger.ts`: Moved `console.timeEnd()` outside the `if (options.inspect)` / `else` branch so it's always called

## Why

When `inspect: true`, the `afterEach` handler called `console.timeLog()` but skipped `console.timeEnd()`, causing a timer leak. On the second call to the same hook, browsers warn "Timer 'hookName' already exists". This affects all browser users of `createDebugger` since `inspect` defaults to `true` in browsers.

Closes #142