### PR TITLE
fix(debugger): stop console timer leak when inspect is enabled

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -68,9 +68,8 @@ export function createDebugger(
     }
     if (options.inspect) {
       console.timeLog(logPrefix(event), event.args);
-    } else {
-      console.timeEnd(logPrefix(event));
     }
+    console.timeEnd(logPrefix(event));
     if (options.group) {
       console.groupEnd();
     }


### PR DESCRIPTION
## Problem

When `inspect: true` (the default in browsers), `createDebugger` calls `console.time()` in `beforeEach` but never calls `console.timeEnd()`. The timer started by `console.time()` leaks on every hook call. On the second call to the same hook, the browser warns:

> Timer 'hookName' already exists

## Root cause

In `src/debugger.ts`, `console.timeEnd()` was inside the `else` branch of the `inspect` check, so it was never reached when `inspect: true`.

## Changes

Moved `console.timeEnd(logPrefix(event))` out of the `else` branch so it always runs, regardless of the `inspect` setting. When `inspect` is enabled, the output includes both the `console.timeLog` (with args) and the `console.timeEnd` (to clean up the timer). When `inspect` is disabled, behavior is unchanged.

## Closes

Closes #142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed debugger timing information handling to consistently finalize timing data across all inspection modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->