### PR TITLE
fix(debugger): end the console timer when `inspect` is enabled

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -68,9 +68,8 @@ export function createDebugger(
     }
     if (options.inspect) {
       console.timeLog(logPrefix(event), event.args);
-    } else {
-      console.timeEnd(logPrefix(event));
     }
+    console.timeEnd(logPrefix(event));
     if (options.group) {
       console.groupEnd();
     }

--- a/test/debuger.test.ts
+++ b/test/debuger.test.ts
@@ -31,6 +31,14 @@ describe("debugger", () => {
     expect(console.time).toBeCalledWith(expect.stringContaining("hook"));
     expect(console.timeLog).toBeCalledWith("hook", []);
   });
+  it("should end the timer when `inspect` is enabled", async () => {
+    createDebugger(hooks, { inspect: true });
+    await hooks.callHook("hook");
+    await hooks.callHook("hook");
+    expect(console.time).toBeCalledTimes(2);
+    expect(console.timeEnd).toBeCalledTimes(2);
+    expect(console.timeEnd).toBeCalledWith("hook");
+  });
   it("should respect `group` option", async () => {
     createDebugger(hooks, { group: true });
     await hooks.callHook("hook");


### PR DESCRIPTION
Fixes #142.

### Problem

In `src/debugger.ts`, `console.timeEnd()` is in the `else` branch of the `inspect` check:

```ts
if (options.inspect) {
  console.timeLog(logPrefix(event), event.args);
} else {
  console.timeEnd(logPrefix(event));
}
```

So with `inspect: true` the timer started by `console.time()` in `beforeEach` is never ended. On the second call of the same hook the browser warns:

> Timer 'hookName' already exists

and the timing for that call is lost. Since `inspect` defaults to `true` in browsers, this affects every browser user of `createDebugger`.

```js
const hooks = new Hookable()
createDebugger(hooks, { inspect: true })
await hooks.callHook("myHook") // timer started, never ended
await hooks.callHook("myHook") // Timer 'myHook' already exists
```

### Change

Call `timeEnd()` unconditionally. When `inspect` is enabled, `timeLog()` still runs first, so the hook args keep being printed next to the elapsed time and the timer is then properly closed — no behaviour is lost, the leak is gone.

### Validation

- Added a regression test in `test/debuger.test.ts` covering two consecutive calls of the same hook with `inspect: true`: it fails on `main` (`timeEnd` called 0 times instead of 2) and passes with this change.
- `pnpm test` (oxlint + oxfmt + vitest with coverage): 4 files, 44 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inspected hook timing output so it includes both timing details and a completed timer result.
  * Ensured repeated inspected hook calls properly end their timers.

* **Tests**
  * Added coverage for timer completion during repeated inspected hook calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->