### PR TITLE
fix(debugger): avoid overlapping timer label reuse

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -73,9 +73,8 @@ export function createDebugger(
     }
     if (options.inspect) {
       console.timeLog(logPrefix(event), event.args);
-    } else {
-      console.timeEnd(logPrefix(event));
     }
+    console.timeEnd(logPrefix(event));
     if (options.group) {
       console.groupEnd();
     }

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -46,15 +46,20 @@ export function createDebugger(
   const _tag = options.tag ? `[${options.tag}] ` : "";
   const logPrefix = (event: any) => _tag + event.name + "".padEnd(event._id, "\0");
 
-  const _idCtr: Record<string, number> = {};
+  const _activeIds: Record<string, Set<number>> = {};
 
   // Before each
   const unsubscribeBefore = hooks.beforeEach((event: any) => {
     if (filter !== undefined && !filter(event.name)) {
       return;
     }
-    _idCtr[event.name] = _idCtr[event.name] || 0;
-    event._id = _idCtr[event.name]++;
+    const activeIds = (_activeIds[event.name] ||= new Set());
+    let id = 0;
+    while (activeIds.has(id)) {
+      id++;
+    }
+    activeIds.add(id);
+    event._id = id;
     console.time(logPrefix(event));
   });
 
@@ -74,7 +79,7 @@ export function createDebugger(
     if (options.group) {
       console.groupEnd();
     }
-    _idCtr[event.name]--;
+    _activeIds[event.name].delete((event as unknown as { _id: number })._id);
   });
 
   return {

--- a/test/debuger.test.ts
+++ b/test/debuger.test.ts
@@ -30,6 +30,7 @@ describe("debugger", () => {
     await hooks.callHook("hook");
     expect(console.time).toBeCalledWith(expect.stringContaining("hook"));
     expect(console.timeLog).toBeCalledWith("hook", []);
+    expect(console.timeEnd).toBeCalledWith("hook");
   });
   it("should respect `group` option", async () => {
     createDebugger(hooks, { group: true });
@@ -68,6 +69,7 @@ describe("debugger", () => {
 
     const labels = vi.mocked(console.time).mock.calls.map(([label]) => label);
     expect(labels).toHaveLength(3);
+    expect(labels[0]).not.toBe(labels[1]);
     expect(labels[2]).not.toBe(labels[1]);
   });
   it("should allowing closing debugger", async () => {

--- a/test/debuger.test.ts
+++ b/test/debuger.test.ts
@@ -51,6 +51,25 @@ describe("debugger", () => {
     await hooks.callHook("other:hook");
     expect(console.time).toBeCalled();
   });
+  it("should keep timer labels unique for overlapping calls", async () => {
+    const pending: Array<() => void> = [];
+    hooks.hook("hook", () => new Promise<void>((resolve) => pending.push(resolve)));
+    createDebugger(hooks, { inspect: false, group: false });
+
+    const first = hooks.callHook("hook");
+    const second = hooks.callHook("hook");
+    pending.shift()!();
+    await first;
+
+    const third = hooks.callHook("hook");
+    pending.shift()!();
+    pending.shift()!();
+    await Promise.all([second, third]);
+
+    const labels = vi.mocked(console.time).mock.calls.map(([label]) => label);
+    expect(labels).toHaveLength(3);
+    expect(labels[2]).not.toBe(labels[1]);
+  });
   it("should allowing closing debugger", async () => {
     const debug = createDebugger(hooks);
     await hooks.callHook("hook");


### PR DESCRIPTION
## Problem

When multiple calls to the same hook overlap and finish out of order, createDebugger can reuse a console timer label that still belongs to a pending call. Browsers key console timers by label, so the later call can collide with the active timer and produce unreliable timing output. This is the race tracked by issue #57.

## Fix

Track the IDs currently in use for each hook and allocate the lowest available ID. Release the ID after the timer handling completes, preserving compact label reuse for sequential calls while keeping overlapping labels distinct.

## Tests

- pnpm exec vitest run test/debuger.test.ts -t should keep timer labels unique for overlapping calls --reporter=verbose - passed
- pnpm test - passed; lint and 44 tests
- pnpm test:types - passed
- pnpm build - passed
- node adjacent label-allocation probe - passed

## Compatibility

No public API changes. The bookkeeping is private to createDebugger; sequential calls continue to reuse freed IDs, and only concurrently active calls require distinct labels.

## Related issue

Fixes #57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debugger timer labeling for overlapping hook calls.
  * Timer IDs are now safely reused after hooks complete while remaining unique during concurrent executions.
  * Debugger timers now close reliably when inspection logging is enabled.

* **Tests**
  * Added coverage for timer cleanup and distinct labels during overlapping hook calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->