### PR TITLE
fix(utils): fallback safely when console.createTask returns undefined or throws

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,13 +63,15 @@ declare global {
   }
 }
 
-const createTask = /* @__PURE__ */ (() => {
-  if (console.createTask) {
-    return console.createTask;
+const defaultTask: ReturnType<CreateTask> = { run: (fn) => fn() };
+
+const createTask: CreateTask = (name) => {
+  try {
+    return console.createTask?.(name) || defaultTask;
+  } catch {
+    return defaultTask;
   }
-  const defaultTask: ReturnType<CreateTask> = { run: (fn) => fn() };
-  return () => defaultTask;
-})();
+};
 
 export function callHooks(
   hooks: HookCallback[],

--- a/test/hookable.test.ts
+++ b/test/hookable.test.ts
@@ -477,4 +477,46 @@ describe("hookable", () => {
     await hooks2.callHook("t", order);
     expect(order).toEqual(["first", "second"]);
   });
+
+  test("does not crash if console.createTask returns undefined or throws", async () => {
+    const originalCreateTask = console.createTask;
+    try {
+      // Test when console.createTask returns undefined
+      console.createTask = vi.fn(() => undefined);
+      const hooks = new Hookable();
+      let called = false;
+      hooks.hook("test", () => {
+        called = true;
+      });
+      await hooks.callHook("test");
+      expect(called).toBe(true);
+
+      let parallelCalled = false;
+      hooks.hook("test-parallel", () => {
+        parallelCalled = true;
+      });
+      await hooks.callHookParallel("test-parallel");
+      expect(parallelCalled).toBe(true);
+
+      // Test when console.createTask throws
+      console.createTask = vi.fn(() => {
+        throw new Error("createTask error");
+      });
+      let throwCalled = false;
+      hooks.hook("test-throw", () => {
+        throwCalled = true;
+      });
+      await hooks.callHook("test-throw");
+      expect(throwCalled).toBe(true);
+
+      let throwParallelCalled = false;
+      hooks.hook("test-throw-parallel", () => {
+        throwParallelCalled = true;
+      });
+      await hooks.callHookParallel("test-throw-parallel");
+      expect(throwParallelCalled).toBe(true);
+    } finally {
+      console.createTask = originalCreateTask;
+    }
+  });
 });


### PR DESCRIPTION
Resolves #114

In certain environments, console proxies, or DevTools wrappers, `console.createTask?.(name)` may return `undefined` or throw an error. When that happens, subsequent calls to `task.run` in `parallelTaskCaller` throw `Cannot read properties of undefined (reading 'run')`.

This change falls back to `defaultTask` if `console.createTask` returns a falsy value or throws, ensuring hook calls always proceed safely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task handling when task creation is unavailable or encounters an error.
  - Hook execution now remains reliable when task creation returns no task or throws an exception.

- **Tests**
  - Added coverage for serial and parallel hooks under task-creation failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->